### PR TITLE
added attribute 'preload=metadata' to audio tag

### DIFF
--- a/src/clld_audio_plugin/datatables.py
+++ b/src/clld_audio_plugin/datatables.py
@@ -11,6 +11,7 @@ class AudioCol(Col):
         if item.audio:
             return HTML.audio(
                 HTML.source(src=item.audio, type="audio/mpeg"),
-                controls="controls"
+                controls="controls",
+                preload="metadata"
             )
         return ''


### PR DESCRIPTION
in order to avoid loading of all audio files when the page loads (esp. for Safari) - see https://www.w3schools.com/tags/att_audio_preload.asp